### PR TITLE
[add] 스터디룸 CRUD 구현완료, 스터디룸 예약 기능 멤버쉽 인증 제외 구현완료

### DIFF
--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -27,7 +27,11 @@ public enum GlobalExceptionConst {
     NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, " 스터디룸이 존재하지 않습니다."),
 
     // 상태코드 409
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다."),
+    ROOM_RESERVE_OVERLAP(HttpStatus.CONFLICT, "예약 시간이 겹쳐 예약이 불가능합니다."),
+
+    // 상태코드 422
+    ROOM_RESERVE_UNPROCESSABLE(HttpStatus.UNPROCESSABLE_ENTITY, "해당 스터디룸 에약이 불가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -15,10 +15,14 @@ public enum GlobalExceptionConst {
     UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, " 비밀번호를 확인해주세요."),
     UNAUTHORIZED_OWNERTOKEN(HttpStatus.UNAUTHORIZED, " 유저 토큰이 틀렸습니다."),
 
+    UNAUTHORIZED_ROOMCONTROL(HttpStatus.UNAUTHORIZED, " 스터디룸 관리 권한이 없습니다."),
+
     // 상태코드 404
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, " 회원이 존재하지 않습니다."),
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, " 이메일을 확인해주세요."),
     DELETED_USER(HttpStatus.NOT_FOUND, " 탈퇴된 회원입니다."),
+
+    NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, " 스터디룸이 존재하지 않습니다."),
 
     // 상태코드 409
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다.");

--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -10,6 +10,7 @@ public enum GlobalExceptionConst {
     // 상태코드 400
     DUPLICATE_PASSWORD(HttpStatus.BAD_REQUEST, " 새 비밀번호는 이전에 사용한 비밀번호와 같을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, " 새 비밀번호는 8자 이상이어야 하고, 숫자와 대문자를 포함해야 합니다."),
+    INSUFFICIENT_DATA_DELIVERED(HttpStatus.BAD_REQUEST, "예약 시작일과 종료일 중 하나는 필수로 입력되어야합니다."),
 
     // 상태코드 401
     UNAUTHORIZED_PASSWORD(HttpStatus.UNAUTHORIZED, " 비밀번호를 확인해주세요."),
@@ -17,6 +18,7 @@ public enum GlobalExceptionConst {
     UNAUTHORIZED_CREATE(HttpStatus.UNAUTHORIZED, " 게시글 권한이 없습니다."),
 
     UNAUTHORIZED_ROOMCONTROL(HttpStatus.UNAUTHORIZED, " 스터디룸 관리 권한이 없습니다."),
+    UNAUTHORIZED_RESERVATION_MODIFICATION(HttpStatus.UNAUTHORIZED, "본인의 스터디룸 예약만 수정할 수 있습니다."),
 
     // 상태코드 404
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, " 회원이 존재하지 않습니다."),
@@ -25,6 +27,7 @@ public enum GlobalExceptionConst {
     NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, " 게시글이 존재하지 않습니다."),
 
     NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, " 스터디룸이 존재하지 않습니다."),
+    NOT_FOUND_ROOM_RESERVE(HttpStatus.NOT_FOUND, " 스터디룸 예약이 존재하지 않습니다."),
 
     // 상태코드 409
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다."),

--- a/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
@@ -1,0 +1,34 @@
+package com.example.library_management.domain.room.controller;
+
+import com.example.library_management.domain.room.dto.request.RoomCreateRequestDto;
+import com.example.library_management.domain.room.dto.response.RoomCreateResponseDto;
+import com.example.library_management.domain.room.dto.request.RoomUpdateRequestDto;
+import com.example.library_management.domain.room.dto.response.RoomDeleteResponseDto;
+import com.example.library_management.domain.room.dto.response.RoomUpdateResponseDto;
+import com.example.library_management.domain.room.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @PostMapping("/library/rooms")
+    public ResponseEntity<RoomCreateResponseDto> createRoom(@RequestBody RoomCreateRequestDto roomCreateRequestDto) {
+        return ResponseEntity.ok(roomService.createRoom(roomCreateRequestDto));
+    }
+
+    @PatchMapping("/library/rooms/{roomId}")
+    public ResponseEntity<RoomUpdateResponseDto> updateRoom(@PathVariable Long roomId, @RequestBody RoomUpdateRequestDto roomUpdateRequestDto) {
+        return ResponseEntity.ok(roomService.updateRoom(roomId, roomUpdateRequestDto));
+    }
+
+    @DeleteMapping("/library/rooms/{roomId}")
+    public ResponseEntity<RoomDeleteResponseDto> deleteRoom(@PathVariable Long roomId) {
+        return ResponseEntity.ok(roomService.deleteRoom(roomId));
+    }
+
+}

--- a/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
@@ -8,6 +8,7 @@ import com.example.library_management.domain.room.dto.response.RoomGetResponseDt
 import com.example.library_management.domain.room.dto.response.RoomUpdateResponseDto;
 import com.example.library_management.domain.room.service.RoomService;
 import com.example.library_management.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,7 +26,7 @@ public class RoomController {
     }
 
     @PostMapping("/library/rooms")
-    public ResponseEntity<RoomCreateResponseDto> createRoom(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody RoomCreateRequestDto roomCreateRequestDto) {
+    public ResponseEntity<RoomCreateResponseDto> createRoom(@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody RoomCreateRequestDto roomCreateRequestDto) {
         return ResponseEntity.ok(roomService.createRoom(userDetails, roomCreateRequestDto));
     }
 

--- a/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/library_management/domain/room/controller/RoomController.java
@@ -4,10 +4,13 @@ import com.example.library_management.domain.room.dto.request.RoomCreateRequestD
 import com.example.library_management.domain.room.dto.response.RoomCreateResponseDto;
 import com.example.library_management.domain.room.dto.request.RoomUpdateRequestDto;
 import com.example.library_management.domain.room.dto.response.RoomDeleteResponseDto;
+import com.example.library_management.domain.room.dto.response.RoomGetResponseDto;
 import com.example.library_management.domain.room.dto.response.RoomUpdateResponseDto;
 import com.example.library_management.domain.room.service.RoomService;
+import com.example.library_management.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,19 +19,24 @@ public class RoomController {
 
     private final RoomService roomService;
 
+    @GetMapping("/library/rooms/{roomId}")
+    public ResponseEntity<RoomGetResponseDto> getRoom(@PathVariable Long roomId){
+        return ResponseEntity.ok(roomService.getRoom(roomId));
+    }
+
     @PostMapping("/library/rooms")
-    public ResponseEntity<RoomCreateResponseDto> createRoom(@RequestBody RoomCreateRequestDto roomCreateRequestDto) {
-        return ResponseEntity.ok(roomService.createRoom(roomCreateRequestDto));
+    public ResponseEntity<RoomCreateResponseDto> createRoom(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody RoomCreateRequestDto roomCreateRequestDto) {
+        return ResponseEntity.ok(roomService.createRoom(userDetails, roomCreateRequestDto));
     }
 
     @PatchMapping("/library/rooms/{roomId}")
-    public ResponseEntity<RoomUpdateResponseDto> updateRoom(@PathVariable Long roomId, @RequestBody RoomUpdateRequestDto roomUpdateRequestDto) {
-        return ResponseEntity.ok(roomService.updateRoom(roomId, roomUpdateRequestDto));
+    public ResponseEntity<RoomUpdateResponseDto> updateRoom(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId, @RequestBody RoomUpdateRequestDto roomUpdateRequestDto) {
+        return ResponseEntity.ok(roomService.updateRoom(userDetails, roomId, roomUpdateRequestDto));
     }
 
     @DeleteMapping("/library/rooms/{roomId}")
-    public ResponseEntity<RoomDeleteResponseDto> deleteRoom(@PathVariable Long roomId) {
-        return ResponseEntity.ok(roomService.deleteRoom(roomId));
+    public ResponseEntity<RoomDeleteResponseDto> deleteRoom(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId) {
+        return ResponseEntity.ok(roomService.deleteRoom(userDetails, roomId));
     }
 
 }

--- a/src/main/java/com/example/library_management/domain/room/dto/request/RoomCreateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/request/RoomCreateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.library_management.domain.room.dto.request;
+
+import com.example.library_management.domain.room.enums.RoomStatus;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomCreateRequestDto {
+
+    @NotBlank
+    private final String roomName;
+
+    @NotBlank
+    private final RoomStatus roomStatus;
+}

--- a/src/main/java/com/example/library_management/domain/room/dto/request/RoomCreateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/request/RoomCreateRequestDto.java
@@ -12,6 +12,5 @@ public class RoomCreateRequestDto {
     @NotBlank
     private final String roomName;
 
-    @NotBlank
     private final RoomStatus roomStatus;
 }

--- a/src/main/java/com/example/library_management/domain/room/dto/request/RoomUpdateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/request/RoomUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.library_management.domain.room.dto.request;
+
+import com.example.library_management.domain.room.enums.RoomStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoomUpdateRequestDto {
+    private String roomName;
+
+    private RoomStatus roomStatus;
+}

--- a/src/main/java/com/example/library_management/domain/room/dto/response/RoomCreateResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/response/RoomCreateResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.library_management.domain.room.dto.response;
+
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.enums.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomCreateResponseDto {
+
+    private final Long id;
+
+    private final String roomName;
+
+    private final RoomStatus roomStatus;
+
+    public RoomCreateResponseDto(Room room){
+        this.id = room.getId();
+        this.roomName = room.getRoomName();
+        this.roomStatus = room.getRoomStatus();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/dto/response/RoomDeleteResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/response/RoomDeleteResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.library_management.domain.room.dto.response;
+
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.enums.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomDeleteResponseDto {
+
+    private Long id;
+
+    private String roomName;
+
+    private RoomStatus roomStatus;
+
+    public RoomDeleteResponseDto(Room deletedRoom) {
+        this.id = deletedRoom.getId();
+        this.roomName = deletedRoom.getRoomName();
+        this.roomStatus = deletedRoom.getRoomStatus();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/dto/response/RoomGetResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/response/RoomGetResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.library_management.domain.room.dto.response;
+
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.enums.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomGetResponseDto {
+
+    private String roomName;
+
+    private RoomStatus roomStatus;
+
+    public RoomGetResponseDto(Room room){
+        this.roomName = room.getRoomName();
+        this.roomStatus = room.getRoomStatus();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/dto/response/RoomUpdateResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/room/dto/response/RoomUpdateResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.library_management.domain.room.dto.response;
+
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.enums.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomUpdateResponseDto {
+
+    private Long id;
+
+    private String roomName;
+
+    private RoomStatus roomStatus;
+
+    public RoomUpdateResponseDto(Room updatedRoom) {
+        this.id = updatedRoom.getId();
+        this.roomName = updatedRoom.getRoomName();
+        this.roomStatus = updatedRoom.getRoomStatus();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/entity/Room.java
+++ b/src/main/java/com/example/library_management/domain/room/entity/Room.java
@@ -40,4 +40,10 @@ public class Room {
         this.roomName = roomUpdateRequestDto.getRoomName();
         this.roomStatus = roomUpdateRequestDto.getRoomStatus();
     }
+
+    // 스터디룸 상태 변경
+    public void updateRoomStatus() {
+        this.roomStatus = (this.roomStatus == RoomStatus.AVAILABLE) ? RoomStatus.NON_AVAILABLE : RoomStatus.AVAILABLE;
+    }
+
 }

--- a/src/main/java/com/example/library_management/domain/room/entity/Room.java
+++ b/src/main/java/com/example/library_management/domain/room/entity/Room.java
@@ -1,5 +1,7 @@
 package com.example.library_management.domain.room.entity;
 
+import com.example.library_management.domain.room.dto.request.RoomCreateRequestDto;
+import com.example.library_management.domain.room.dto.request.RoomUpdateRequestDto;
 import com.example.library_management.domain.room.enums.RoomStatus;
 import com.example.library_management.domain.roomReserve.entity.RoomReserve;
 import jakarta.persistence.*;
@@ -22,6 +24,20 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private RoomStatus roomStatus;
 
-    @OneToMany(mappedBy = "room")
+    // 해당 Room에 대한 예약 정보 List
+    @OneToMany(mappedBy = "room", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<RoomReserve> roomReservations = new ArrayList<>();
+
+    public static Room createRoom(RoomCreateRequestDto roomCreateRequestDto) {
+        Room room = new Room();
+        room.roomName = roomCreateRequestDto.getRoomName();
+        room.roomStatus = roomCreateRequestDto.getRoomStatus();
+        return room;
+    }
+
+    // 스터디룸 수정
+    public void update(RoomUpdateRequestDto roomUpdateRequestDto) {
+        this.roomName = roomUpdateRequestDto.getRoomName();
+        this.roomStatus = roomUpdateRequestDto.getRoomStatus();
+    }
 }

--- a/src/main/java/com/example/library_management/domain/room/exception/NotFoundRoomException.java
+++ b/src/main/java/com/example/library_management/domain/room/exception/NotFoundRoomException.java
@@ -1,0 +1,12 @@
+package com.example.library_management.domain.room.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+import com.example.library_management.domain.common.exception.GlobalExceptionConst;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.NOT_FOUND_ROOM;
+
+public class NotFoundRoomException extends GlobalException {
+    public NotFoundRoomException() {
+        super(NOT_FOUND_ROOM);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/exception/UnauthorizedRoomAccessException.java
+++ b/src/main/java/com/example/library_management/domain/room/exception/UnauthorizedRoomAccessException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.room.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.UNAUTHORIZED_ROOMCONTROL;
+
+public class UnauthorizedRoomAccessException extends GlobalException {
+    public UnauthorizedRoomAccessException() {
+        super(UNAUTHORIZED_ROOMCONTROL);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/example/library_management/domain/room/repository/RoomRepository.java
@@ -1,0 +1,10 @@
+package com.example.library_management.domain.room.repository;
+
+import com.example.library_management.domain.room.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    boolean existsById(Long id);
+
+}

--- a/src/main/java/com/example/library_management/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/library_management/domain/room/service/RoomService.java
@@ -49,7 +49,7 @@ public class RoomService {
         // 요청자 권한 확인
         validateRoomAccess(userDetails);
 
-        // 로직   -> CustomException 변경해야함.
+        // 로직
         Room updatedRoom = findRoomById(roomId);
 
         updatedRoom.update(roomUpdateRequestDto);
@@ -83,7 +83,8 @@ public class RoomService {
     public void validateRoomAccess(UserDetailsImpl userDetails){
         // 사용자가 ADMIN 권한을 가지고 있는지 확인
         boolean isAdmin = userDetails.getAuthorities().stream()
-                .anyMatch(authority -> authority.getAuthority().equals("ADMIN"));
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+        System.out.println("권한 :"+userDetails.getAuthorities());
 
         if (!isAdmin) {
             throw new UnauthorizedRoomAccessException();

--- a/src/main/java/com/example/library_management/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/library_management/domain/room/service/RoomService.java
@@ -1,0 +1,66 @@
+package com.example.library_management.domain.room.service;
+
+import com.example.library_management.domain.room.dto.request.RoomCreateRequestDto;
+import com.example.library_management.domain.room.dto.request.RoomUpdateRequestDto;
+import com.example.library_management.domain.room.dto.response.RoomCreateResponseDto;
+import com.example.library_management.domain.room.dto.response.RoomDeleteResponseDto;
+import com.example.library_management.domain.room.dto.response.RoomUpdateResponseDto;
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public RoomCreateResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto) {
+        // JWT 토큰 -> 요청자 권한 확인, ADMIN인지 확인
+
+        // 로직
+        Room room = Room.createRoom(roomCreateRequestDto);
+
+        Room savedRoom = roomRepository.save(room);
+
+        return new RoomCreateResponseDto(savedRoom);
+    }
+
+    @Transactional
+    public RoomUpdateResponseDto updateRoom(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto) {
+        // JWT 토큰 -> 요청자 권한 확인, ADMIN인지 확인
+
+        // 로직   -> CustomException 변경해야함.
+        Room updatedRoom = findRoomById(roomId);
+
+        updatedRoom.update(roomUpdateRequestDto);
+
+        return new RoomUpdateResponseDto(updatedRoom);
+    }
+
+    @Transactional
+    public RoomDeleteResponseDto deleteRoom(Long roomId) {
+        // JWT 토큰 -> 요청자 권한 확인, ADMIN인지 확인
+
+        // 로직
+        Room deletedRoom = findRoomById(roomId);
+
+        // CascadeType.REMOVE로 Room과 연관된 RoomReserve 자동 삭제.
+        roomRepository.delete(deletedRoom);
+
+        return new RoomDeleteResponseDto(deletedRoom);
+    }
+
+    // Room 조회
+    public Room findRoomById(Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new NoSuchElementException("전달된 id 값에 해당하는 Room 엔티티가 존재하지 않습니다."));
+
+        return room;
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
@@ -1,5 +1,6 @@
 package com.example.library_management.domain.roomReserve.controller;
 
+import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
 import com.example.library_management.domain.roomReserve.service.RoomReserveService;
 import com.example.library_management.global.security.UserDetailsImpl;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,7 +19,11 @@ public class RoomReserveController {
     private final RoomReserveService roomReserveService;
 
     @PostMapping("/library/rooms/{roomId}/reservations")
-    public ResponseEntity<RoomReserveCreateResponseDto> createRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId){
-        return ResponseEntity.ok(roomReserveService.createRoomReserve(userDetails, roomId));
+    public ResponseEntity<RoomReserveCreateResponseDto> createRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @PathVariable Long roomId,
+                                                                          @RequestBody RoomReserveCreateRequestDto roomReserveCreateRequestDto){
+        return ResponseEntity.ok(roomReserveService.createRoomReserve(userDetails, roomId, roomReserveCreateRequestDto));
     }
+
+
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
@@ -1,0 +1,23 @@
+package com.example.library_management.domain.roomReserve.controller;
+
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
+import com.example.library_management.domain.roomReserve.service.RoomReserveService;
+import com.example.library_management.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RoomReserveController {
+
+    private final RoomReserveService roomReserveService;
+
+    @PostMapping("/library/rooms/{roomId}/reservations")
+    public ResponseEntity<RoomReserveCreateResponseDto> createRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId){
+        return ResponseEntity.ok(roomReserveService.createRoomReserve(userDetails, roomId));
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
@@ -1,16 +1,16 @@
 package com.example.library_management.domain.roomReserve.controller;
 
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
+import com.example.library_management.domain.roomReserve.dto.request.RoomReserveUpdateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveUpdateResponseDto;
 import com.example.library_management.domain.roomReserve.service.RoomReserveService;
 import com.example.library_management.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +25,15 @@ public class RoomReserveController {
         return ResponseEntity.ok(roomReserveService.createRoomReserve(userDetails, roomId, roomReserveCreateRequestDto));
     }
 
+    @PatchMapping("/library/rooms/{roomId}/reservations/{reserveId}")
+    public ResponseEntity<RoomReserveUpdateResponseDto> updateRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @PathVariable Long roomId,
+                                                                          @PathVariable Long reserveId,
+                                                                          @RequestBody RoomReserveUpdateRequestDto roomReserveUpdateRequestDto){
+        // (예약 시작일, 예약 종료일) 둘 중 최소 하나 이상의 데이터의 전달 유무 검증.
+        roomReserveUpdateRequestDto.validate();
+
+        return ResponseEntity.ok(roomReserveService.updateRoomReserve(userDetails, roomId, reserveId, roomReserveUpdateRequestDto));
+    }
 
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveCreateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveCreateRequestDto.java
@@ -10,10 +10,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class RoomReserveCreateRequestDto {
 
-    @NotBlank
     private final LocalDateTime reservationDate;
 
-    @NotBlank
     private final LocalDateTime reservationDateEnd;
 
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveCreateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.library_management.domain.roomReserve.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveCreateRequestDto {
+
+    @NotBlank
+    private final LocalDateTime reservationDate;
+
+    @NotBlank
+    private final LocalDateTime reservationDateEnd;
+
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveUpdateRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/request/RoomReserveUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.library_management.domain.roomReserve.dto.request;
+
+import com.example.library_management.domain.roomReserve.exception.AtLeastOneFieldRequiredException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveUpdateRequestDto {
+
+    private LocalDateTime reservationDate;
+
+    private LocalDateTime reservationDateEnd;
+
+    public void validate(){
+        if(reservationDate == null && reservationDateEnd == null){
+            throw new AtLeastOneFieldRequiredException();
+        }
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveCreateResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveCreateResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.library_management.domain.roomReserve.dto.response;
+
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveCreateResponseDto {
+
+    private final Long id;
+
+    private final LocalDateTime reservationDate;    //예약 시작일
+
+    private final LocalDateTime reservationDateEnd; //예약 종료일
+
+    // Timestamp로 정의한 생성일과, 수정일
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime modifiedAt;
+
+    public RoomReserveCreateResponseDto(RoomReserve roomReserve) {
+        this.id = roomReserve.getId();
+        this.reservationDate = roomReserve.getReservationDate();
+        this.reservationDateEnd = roomReserve.getReservationDateEnd();
+        this.createdAt = roomReserve.getCreatedAt();
+        this.modifiedAt = roomReserve.getModifiedAt();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveCreateResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveCreateResponseDto.java
@@ -12,6 +12,8 @@ public class RoomReserveCreateResponseDto {
 
     private final Long id;
 
+    private final Long userId;
+
     private final LocalDateTime reservationDate;    //예약 시작일
 
     private final LocalDateTime reservationDateEnd; //예약 종료일
@@ -23,6 +25,7 @@ public class RoomReserveCreateResponseDto {
 
     public RoomReserveCreateResponseDto(RoomReserve roomReserve) {
         this.id = roomReserve.getId();
+        this.userId = roomReserve.getUser().getId();
         this.reservationDate = roomReserve.getReservationDate();
         this.reservationDateEnd = roomReserve.getReservationDateEnd();
         this.createdAt = roomReserve.getCreatedAt();

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveUpdateResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveUpdateResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.library_management.domain.roomReserve.dto.response;
+
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveUpdateResponseDto {
+    private final Long id;
+
+    private final Long userId;
+
+    private final LocalDateTime reservationDate;    //예약 시작일
+
+    private final LocalDateTime reservationDateEnd; //예약 종료일
+
+    // Timestamp로 정의한 생성일과, 수정일
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime modifiedAt;
+
+    public RoomReserveUpdateResponseDto(RoomReserve roomReserve) {
+        this.id = roomReserve.getId();
+        this.userId = roomReserve.getUser().getId();
+        this.reservationDate = roomReserve.getReservationDate();
+        this.reservationDateEnd = roomReserve.getReservationDateEnd();
+        this.createdAt = roomReserve.getCreatedAt();
+        this.modifiedAt = roomReserve.getModifiedAt();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
@@ -41,4 +41,12 @@ public class RoomReserve extends Timestamped {
         return roomReserve;
     }
 
+    public void updateReservationDate(LocalDateTime reservationDate) {
+        this.reservationDate = reservationDate;
+    }
+
+    public void updateReservationDateEnd(LocalDateTime reservationDateEnd) {
+        this.reservationDateEnd = reservationDateEnd;
+    }
+
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
@@ -2,6 +2,7 @@ package com.example.library_management.domain.roomReserve.entity;
 
 import com.example.library_management.domain.common.entity.Timestamped;
 import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
 import com.example.library_management.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -30,4 +31,14 @@ public class RoomReserve extends Timestamped {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;
+
+    public static RoomReserve createReservation(Room room, User user, RoomReserveCreateRequestDto roomReserveCreateRequestDto) {
+        RoomReserve roomReserve = new RoomReserve();
+        roomReserve.room = room;
+        roomReserve.user = user;
+        roomReserve.reservationDate = roomReserveCreateRequestDto.getReservationDate();
+        roomReserve.reservationDateEnd = roomReserveCreateRequestDto.getReservationDateEnd();
+        return roomReserve;
+    }
+
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
@@ -12,12 +12,14 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "room_reserve")
 public class RoomReserve extends Timestamped {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
     private LocalDateTime reservationDate;
+
     @Column(nullable = false)
     private LocalDateTime reservationDateEnd;
 

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/AtLeastOneFieldRequiredException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/AtLeastOneFieldRequiredException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.INSUFFICIENT_DATA_DELIVERED;
+
+public class AtLeastOneFieldRequiredException extends GlobalException {
+    public AtLeastOneFieldRequiredException() {
+        super(INSUFFICIENT_DATA_DELIVERED);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/NotFoundRoomReserveException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/NotFoundRoomReserveException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.NOT_FOUND_ROOM_RESERVE;
+
+public class NotFoundRoomReserveException extends GlobalException{
+    public NotFoundRoomReserveException() {
+        super(NOT_FOUND_ROOM_RESERVE);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationModificationNotAllowedException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationModificationNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.UNAUTHORIZED_RESERVATION_MODIFICATION;
+
+public class ReservationModificationNotAllowedException extends GlobalException {
+    public ReservationModificationNotAllowedException() {
+        super(UNAUTHORIZED_RESERVATION_MODIFICATION);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveOverlapException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveOverlapException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.ROOM_RESERVE_OVERLAP;
+
+public class RoomReserveOverlapException extends GlobalException {
+    public RoomReserveOverlapException() {
+        super(ROOM_RESERVE_OVERLAP);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveUnavailableException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveUnavailableException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.ROOM_RESERVE_UNPROCESSABLE;
+
+public class RoomReserveUnavailableException extends GlobalException {
+    public RoomReserveUnavailableException() {
+        super(ROOM_RESERVE_UNPROCESSABLE);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
@@ -1,0 +1,8 @@
+package com.example.library_management.domain.roomReserve.repository;
+
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomReserveRepository extends JpaRepository<RoomReserve, Long> {
+
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
@@ -1,0 +1,27 @@
+package com.example.library_management.domain.roomReserve.service;
+
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import com.example.library_management.domain.roomReserve.repository.RoomReserveRepository;
+import com.example.library_management.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomReserveService {
+
+    private final RoomReserveRepository roomReserveRepository;
+
+
+    public RoomReserveCreateResponseDto createRoomReserve(UserDetailsImpl userDetails, Long roomId) {
+        // 요청자 권한 확인
+
+        // 로직
+
+        RoomReserve roomReserve = new RoomReserve();
+        roomReserveRepository.save(roomReserve);
+
+        return new RoomReserveCreateResponseDto(roomReserve);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
@@ -1,27 +1,85 @@
 package com.example.library_management.domain.roomReserve.service;
 
+import com.example.library_management.domain.room.entity.Room;
+import com.example.library_management.domain.room.enums.RoomStatus;
+import com.example.library_management.domain.room.service.RoomService;
+import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
 import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import com.example.library_management.domain.roomReserve.exception.RoomReserveOverlapException;
+import com.example.library_management.domain.roomReserve.exception.RoomReserveUnavailableException;
 import com.example.library_management.domain.roomReserve.repository.RoomReserveRepository;
+import com.example.library_management.domain.user.entity.User;
 import com.example.library_management.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RoomReserveService {
 
     private final RoomReserveRepository roomReserveRepository;
+    private final RoomService roomService;
 
+    @Transactional
+    public RoomReserveCreateResponseDto createRoomReserve(UserDetailsImpl userDetails, Long roomId, RoomReserveCreateRequestDto roomReserveCreateRequestDto) {
+        // 요청자 권한 확인    - 멤버쉽 권한 만이 스터디룸 예약을 할 수 있다.
+        // User 객체의 멤버쉽 권한 확인 로직 미추가상태. - 10/23
+        User user = userDetails.getUser();
 
-    public RoomReserveCreateResponseDto createRoomReserve(UserDetailsImpl userDetails, Long roomId) {
-        // 요청자 권한 확인
+        // 예약하고자 하는 roomId 의 예약 가능 여부 확인.
+        /*
+            RoomStatus -> AVAILABLE
+            if 입력받은 예약시간 정보가 예약 가능한가? -> 로직 수행.
+            else -> Exception throw
+
+            RoomStatus -> NON_AVAILABLE
+            if 관리자에 의해 폐쇠한 상태이다 -> Exception throw (RoomStatus enum 수정필요 부분)
+            else -> Exception throw (모든 시간이 예약되어 예약 불가능한 상태)
+         */
+        Room room = roomService.findRoomById(roomId);
+
+        if(room.getRoomStatus() == RoomStatus.NON_AVAILABLE){
+            throw new RoomReserveUnavailableException();
+        }
+
+        /*
+         RoomReserveCreateRequestDto의 reservationDate와 reservationDateEnd가 기존의 예약과 겹치는지 유무 판별.
+         예약이 겹치는 Case
+         Case 1: 새로운 예약의 reservationDate가 기존 예약 사이에 있는 경우
+         Case 2: 새로운 예약의 reservationDateEnd가 기존 예약 사이에 있는 경우
+         Case 3: 새로운 예약이 기존 예약을 덮거나, 기존 예약이 새로운 예약을 덮는 경우.
+         */
+
+        List<RoomReserve> roomReserveList = room.getRoomReservations();
+
+        LocalDateTime reservationDate = roomReserveCreateRequestDto.getReservationDate();
+        LocalDateTime reservationDateEnd = roomReserveCreateRequestDto.getReservationDateEnd();
+
+        for(RoomReserve existingReserve: roomReserveList){
+            // 기존 예약 시간
+            LocalDateTime existingStartTime = existingReserve.getReservationDate();
+            LocalDateTime existingEndTime = existingReserve.getReservationDateEnd();
+
+            // 예약이 겹치는 Case 3가지를 판별하는 로직.
+            boolean isOverlap = reservationDate.isBefore(existingEndTime) && reservationDateEnd.isAfter(existingStartTime);
+
+            // 겹치는 예약? -> Exception
+            if(isOverlap){
+                throw new RoomReserveOverlapException();
+            }
+        }
 
         // 로직
 
-        RoomReserve roomReserve = new RoomReserve();
-        roomReserveRepository.save(roomReserve);
+        RoomReserve roomReserve = RoomReserve.createReservation(room, user, roomReserveCreateRequestDto);
 
-        return new RoomReserveCreateResponseDto(roomReserve);
+        RoomReserve savedRoomReserve = roomReserveRepository.save(roomReserve);
+
+        return new RoomReserveCreateResponseDto(savedRoomReserve);
     }
 }


### PR DESCRIPTION
스터디룸 domain 관련 기본적인 CRUD 기능 구현을 완료했습니다.

스터디룸예약 domain 관련해서는 스터디룸 예약 create 기능만 구현한 상태이며, 해당 부분은 처리시
요청자의 멤버쉽 권한을 확인하는 작업이 선행되어야 하는데 이 부분은 아직 미구현상태이므로, 멤버쉽 권한 확인 부분은 제외한
나머지 기능을 구현 완료했습니다.

스터디룸 예약관련한 나머지 RUD 기능도 이어서 개발하도록 하겠습니다.

코드 작성간 많이 미숙한 점이 많습니다, 피드백 주시면 협업과 개인적 성장을 위해 최대한 수용하도록 노력하겠습니다.

2024/10/24 추가 내용 
작성한 내용인 스터디룸 CRUD 및 스터디룸 예약 C 기능에 대해서 Postman을 사용한 테스트를 완료했습니다.

ROLE_ADMIN 권한과, ROLE_USER 권한을 가진 유저를 각각 생성해서

ROLE_ADMIN 권한을 보유했을때만 스터디룸 CRUD 요청이 수행되는 점을 확인했고

스터디룸 예약의 경우는 현재 멤버쉽 권한은 제외한 상태로 어떠한 권한이든 요청이 받아들여질 수 있도록 했습니다.