### PR TITLE
[add] 스터디룸 예약 삭제/조회/수정 기능 추가

### DIFF
--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -28,6 +28,7 @@ public enum GlobalExceptionConst {
 
     UNAUTHORIZED_ROOMCONTROL(HttpStatus.UNAUTHORIZED, " 스터디룸 관리 권한이 없습니다."),
     UNAUTHORIZED_RESERVATION_MODIFICATION(HttpStatus.UNAUTHORIZED, "본인의 스터디룸 예약만 수정할 수 있습니다."),
+    UNAUTHORIZED_RESERVATION_DELETE(HttpStatus.UNAUTHORIZED, "본인의 스터디룸 예약만 삭제할 수 있습니다."),
 
     // 상태코드 404
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, " 회원이 존재하지 않습니다."),

--- a/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
@@ -3,6 +3,7 @@ package com.example.library_management.domain.roomReserve.controller;
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveUpdateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveDeleteResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveUpdateResponseDto;
 import com.example.library_management.domain.roomReserve.service.RoomReserveService;
 import com.example.library_management.global.security.UserDetailsImpl;
@@ -34,6 +35,13 @@ public class RoomReserveController {
         roomReserveUpdateRequestDto.validate();
 
         return ResponseEntity.ok(roomReserveService.updateRoomReserve(userDetails, roomId, reserveId, roomReserveUpdateRequestDto));
+    }
+
+    @DeleteMapping("/library/rooms/{roomId}/reservations/{reserveId}")
+    public ResponseEntity<RoomReserveDeleteResponseDto> deleteRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @PathVariable Long roomId,
+                                                                          @PathVariable Long reserveId){
+        return ResponseEntity.ok(roomReserveService.deleteRoomReserve(userDetails, roomId, reserveId));
     }
 
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/controller/RoomReserveController.java
@@ -4,11 +4,13 @@ import com.example.library_management.domain.roomReserve.dto.request.RoomReserve
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveUpdateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveDeleteResponseDto;
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveUpdateResponseDto;
 import com.example.library_management.domain.roomReserve.service.RoomReserveService;
 import com.example.library_management.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +24,7 @@ public class RoomReserveController {
     @PostMapping("/library/rooms/{roomId}/reservations")
     public ResponseEntity<RoomReserveCreateResponseDto> createRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                           @PathVariable Long roomId,
-                                                                          @RequestBody RoomReserveCreateRequestDto roomReserveCreateRequestDto){
+                                                                          @RequestBody RoomReserveCreateRequestDto roomReserveCreateRequestDto) {
         return ResponseEntity.ok(roomReserveService.createRoomReserve(userDetails, roomId, roomReserveCreateRequestDto));
     }
 
@@ -30,7 +32,7 @@ public class RoomReserveController {
     public ResponseEntity<RoomReserveUpdateResponseDto> updateRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                           @PathVariable Long roomId,
                                                                           @PathVariable Long reserveId,
-                                                                          @RequestBody RoomReserveUpdateRequestDto roomReserveUpdateRequestDto){
+                                                                          @RequestBody RoomReserveUpdateRequestDto roomReserveUpdateRequestDto) {
         // (예약 시작일, 예약 종료일) 둘 중 최소 하나 이상의 데이터의 전달 유무 검증.
         roomReserveUpdateRequestDto.validate();
 
@@ -40,8 +42,22 @@ public class RoomReserveController {
     @DeleteMapping("/library/rooms/{roomId}/reservations/{reserveId}")
     public ResponseEntity<RoomReserveDeleteResponseDto> deleteRoomReserve(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                           @PathVariable Long roomId,
-                                                                          @PathVariable Long reserveId){
+                                                                          @PathVariable Long reserveId) {
         return ResponseEntity.ok(roomReserveService.deleteRoomReserve(userDetails, roomId, reserveId));
     }
 
+    @GetMapping("/library/rooms/{roomId}/reservations")
+    public ResponseEntity<Page<RoomReserveResponseDto>> findAllRoomReserve(@RequestParam(defaultValue = "1") int page,
+                                                                           @RequestParam(defaultValue = "10") int size,
+                                                                           @PathVariable Long roomId) {
+        return ResponseEntity.ok(roomReserveService.findAllRoomReserve(page, size, roomId));
+    }
+
+    @GetMapping("/library/rooms/{roomId}/reservations/users")
+    public ResponseEntity<Page<RoomReserveResponseDto>> findAllRoomReserveByUser(@RequestParam(defaultValue = "1") int page,
+                                                                      @RequestParam(defaultValue = "10") int size,
+                                                                      @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                      @PathVariable Long roomId) {
+        return ResponseEntity.ok(roomReserveService.findAllRoomReserveByUser(page, size, userDetails, roomId));
+    }
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveDeleteResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveDeleteResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.library_management.domain.roomReserve.dto.response;
+
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveDeleteResponseDto {
+    private final Long id;
+
+    private final Long userId;
+
+    private final LocalDateTime reservationDate;    //예약 시작일
+
+    private final LocalDateTime reservationDateEnd; //예약 종료일
+
+    // Timestamp로 정의한 생성일과, 수정일
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime modifiedAt;
+
+    public RoomReserveDeleteResponseDto(RoomReserve roomReserve) {
+        this.id = roomReserve.getId();
+        this.userId = roomReserve.getUser().getId();
+        this.reservationDate = roomReserve.getReservationDate();
+        this.reservationDateEnd = roomReserve.getReservationDateEnd();
+        this.createdAt = roomReserve.getCreatedAt();
+        this.modifiedAt = roomReserve.getModifiedAt();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/dto/response/RoomReserveResponseDto.java
@@ -1,0 +1,34 @@
+package com.example.library_management.domain.roomReserve.dto.response;
+
+import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RoomReserveResponseDto {
+    private Long id;
+
+    private Long userId;
+
+    private LocalDateTime reservationDate;    //예약 시작일
+
+    private LocalDateTime reservationDateEnd; //예약 종료일
+
+    // Timestamp로 정의한 생성일과, 수정일
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    public RoomReserveResponseDto(RoomReserve roomReserve) {
+        this.id = roomReserve.getId();
+        this.userId = roomReserve.getUser().getId();
+        this.reservationDate = roomReserve.getReservationDate();
+        this.reservationDateEnd = roomReserve.getReservationDateEnd();
+        this.createdAt = roomReserve.getCreatedAt();
+        this.modifiedAt = roomReserve.getModifiedAt();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationDeleteNotAllowedException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationDeleteNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.UNAUTHORIZED_RESERVATION_DELETE;
+
+public class ReservationDeleteNotAllowedException extends GlobalException {
+    public ReservationDeleteNotAllowedException() {
+        super(UNAUTHORIZED_RESERVATION_DELETE);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
@@ -1,8 +1,18 @@
 package com.example.library_management.domain.roomReserve.repository;
 
+import com.example.library_management.domain.review.entity.Review;
 import com.example.library_management.domain.roomReserve.entity.RoomReserve;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomReserveRepository extends JpaRepository<RoomReserve, Long> {
 
+    @Query("SELECT r FROM RoomReserve r WHERE r.user.id = :userId AND r.room.id = :roomId")
+    Page<RoomReserve> findAllByUserIdAndRoomId(@Param("userId") Long userId, @Param("roomId") Long roomId, Pageable pageable);
+
+    @Query("SELECT r from RoomReserve r WHERE r.room.id = :roomId")
+    Page<RoomReserve> findAllByRoomId(@Param("roomId") Long roomId, Pageable pageable);
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
@@ -7,6 +7,7 @@ import com.example.library_management.domain.roomReserve.dto.request.RoomReserve
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveUpdateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveDeleteResponseDto;
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveUpdateResponseDto;
 import com.example.library_management.domain.roomReserve.entity.RoomReserve;
 import com.example.library_management.domain.roomReserve.exception.*;
@@ -14,6 +15,10 @@ import com.example.library_management.domain.roomReserve.repository.RoomReserveR
 import com.example.library_management.domain.user.entity.User;
 import com.example.library_management.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +50,7 @@ public class RoomReserveService {
          */
         Room room = roomService.findRoomById(roomId);
 
-        if(room.getRoomStatus() == RoomStatus.NON_AVAILABLE){
+        if (room.getRoomStatus() == RoomStatus.NON_AVAILABLE) {
             throw new RoomReserveUnavailableException();
         }
 
@@ -62,7 +67,7 @@ public class RoomReserveService {
         LocalDateTime reservationDate = roomReserveCreateRequestDto.getReservationDate();
         LocalDateTime reservationDateEnd = roomReserveCreateRequestDto.getReservationDateEnd();
 
-        for(RoomReserve existingReserve: roomReserveList){
+        for (RoomReserve existingReserve : roomReserveList) {
             // 기존 예약 시간
             LocalDateTime existingStartTime = existingReserve.getReservationDate();
             LocalDateTime existingEndTime = existingReserve.getReservationDateEnd();
@@ -71,7 +76,7 @@ public class RoomReserveService {
             boolean isOverlap = reservationDate.isBefore(existingEndTime) && reservationDateEnd.isAfter(existingStartTime);
 
             // 겹치는 예약? -> Exception
-            if(isOverlap){
+            if (isOverlap) {
                 throw new RoomReserveOverlapException();
             }
         }
@@ -99,27 +104,27 @@ public class RoomReserveService {
 
 
         // 예약자의 ID와 요청자의 ID가 동일한지 검증
-        if(!filteredRoomReserve.getUser().getId().equals(userDetails.getUser().getId())){
+        if (!filteredRoomReserve.getUser().getId().equals(userDetails.getUser().getId())) {
             throw new ReservationModificationNotAllowedException();
         }
-        
+
         // 수정 요청받은 시간 정보가 기존 예약과 겹치는지 판별    -   10/24 현재 다른 사용자의 예약정보와 겹칠 수 있는 문제가 있음.
         List<RoomReserve> roomReserveList = room.getRoomReservations();
 
         // 요청받은 예약 시간 변경 정보 - 둘 중 하나 이상의 값이 전달.
-        if(roomReserveUpdateRequestDto.getReservationDate() != null){
+        if (roomReserveUpdateRequestDto.getReservationDate() != null) {
             filteredRoomReserve.updateReservationDate(roomReserveUpdateRequestDto.getReservationDate());
         }
-        if(roomReserveUpdateRequestDto.getReservationDateEnd() != null){
+        if (roomReserveUpdateRequestDto.getReservationDateEnd() != null) {
             filteredRoomReserve.updateReservationDateEnd(roomReserveUpdateRequestDto.getReservationDateEnd());
         }
 
         LocalDateTime reservationDate = filteredRoomReserve.getReservationDate();
         LocalDateTime reservationDateEnd = filteredRoomReserve.getReservationDateEnd();
 
-        for(RoomReserve existingReserve: roomReserveList){
+        for (RoomReserve existingReserve : roomReserveList) {
             // 기존의 자신의 예약과의 비교는 제외
-            if(!existingReserve.getId().equals(filteredRoomReserve.getId())){
+            if (!existingReserve.getId().equals(filteredRoomReserve.getId())) {
                 // 기존 예약 시간
                 LocalDateTime existingStartTime = existingReserve.getReservationDate();
                 LocalDateTime existingEndTime = existingReserve.getReservationDateEnd();
@@ -128,7 +133,7 @@ public class RoomReserveService {
                 boolean isOverlap = reservationDate.isBefore(existingEndTime) && reservationDateEnd.isAfter(existingStartTime);
 
                 // 겹치는 예약? -> Exception
-                if(isOverlap){
+                if (isOverlap) {
                     throw new RoomReserveOverlapException();
                 }
             }
@@ -150,12 +155,39 @@ public class RoomReserveService {
                 .findFirst().orElseThrow(NotFoundRoomReserveException::new);
 
         // 스터디룸 예약을 했던 유저만이 스터디룸 예약을 삭제 할 수 있다.
-        if(!filteredRoomReserve.getUser().getId().equals(userDetails.getUser().getId())){
+        if (!filteredRoomReserve.getUser().getId().equals(userDetails.getUser().getId())) {
             throw new ReservationDeleteNotAllowedException();
         }
 
         roomReserveRepository.delete(filteredRoomReserve);
 
         return new RoomReserveDeleteResponseDto(filteredRoomReserve);
+    }
+
+    /*
+        roomId를 가지는 Room의 모든 RoomReserv를 Get -> 권한 확인 X
+        비 로그인 상태에서 해당 스터디룸의 예약상황을 확인하는데에 사용.
+     */
+    @Transactional(readOnly = true)
+    public Page<RoomReserveResponseDto> findAllRoomReserve(int page, int size, Long roomId) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<RoomReserve> roomReservePage = roomReserveRepository.findAllByRoomId(roomId, pageable);
+
+        return roomReservePage.map(RoomReserveResponseDto::new);
+    }
+
+    /*
+        roomId를 가지는 Room의 RoomReserve에서 userDetails의 user가 신청한 RoomReserve들을 Get
+     */
+    @Transactional(readOnly = true)
+    public Page<RoomReserveResponseDto> findAllRoomReserveByUser(int page, int size, UserDetailsImpl userDetails, Long roomId) {
+        Pageable pageable = PageRequest.of(page - 1, size);  // 페이지는 0부터 시작
+        Long userId = userDetails.getUser().getId();
+
+        Page<RoomReserve> roomReservePage = roomReserveRepository.findAllByUserIdAndRoomId(userId, roomId, pageable);
+
+        return roomReservePage.map(RoomReserveResponseDto::new);
+
     }
 }

--- a/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/service/RoomReserveService.java
@@ -6,12 +6,10 @@ import com.example.library_management.domain.room.service.RoomService;
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveCreateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.request.RoomReserveUpdateRequestDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveCreateResponseDto;
+import com.example.library_management.domain.roomReserve.dto.response.RoomReserveDeleteResponseDto;
 import com.example.library_management.domain.roomReserve.dto.response.RoomReserveUpdateResponseDto;
 import com.example.library_management.domain.roomReserve.entity.RoomReserve;
-import com.example.library_management.domain.roomReserve.exception.NotFoundRoomReserveException;
-import com.example.library_management.domain.roomReserve.exception.ReservationModificationNotAllowedException;
-import com.example.library_management.domain.roomReserve.exception.RoomReserveOverlapException;
-import com.example.library_management.domain.roomReserve.exception.RoomReserveUnavailableException;
+import com.example.library_management.domain.roomReserve.exception.*;
 import com.example.library_management.domain.roomReserve.repository.RoomReserveRepository;
 import com.example.library_management.domain.user.entity.User;
 import com.example.library_management.global.security.UserDetailsImpl;
@@ -89,6 +87,9 @@ public class RoomReserveService {
 
     @Transactional
     public RoomReserveUpdateResponseDto updateRoomReserve(UserDetailsImpl userDetails, Long roomId, Long reserveId, RoomReserveUpdateRequestDto roomReserveUpdateRequestDto) {
+        // 요청자 권한 확인    - 해당 스터디룸 예약을 했던 유저만이 스터디룸 예약을 수정 할 수 있다.
+        User user = userDetails.getUser();
+
         // 예약 정보 확인.
         Room room = roomService.findRoomById(roomId);
 
@@ -102,21 +103,59 @@ public class RoomReserveService {
             throw new ReservationModificationNotAllowedException();
         }
         
-        // 수정 요청받은 시간 정보가 기존 예약과 겹치는지
+        // 수정 요청받은 시간 정보가 기존 예약과 겹치는지 판별    -   10/24 현재 다른 사용자의 예약정보와 겹칠 수 있는 문제가 있음.
+        List<RoomReserve> roomReserveList = room.getRoomReservations();
 
-
-
-        
-
-        // 로직 - 예약 시간의 시작과 끝 둘 중 하나 혹은 둘 다 전달되는 경우를 처리.
+        // 요청받은 예약 시간 변경 정보 - 둘 중 하나 이상의 값이 전달.
         if(roomReserveUpdateRequestDto.getReservationDate() != null){
             filteredRoomReserve.updateReservationDate(roomReserveUpdateRequestDto.getReservationDate());
         }
-
         if(roomReserveUpdateRequestDto.getReservationDateEnd() != null){
             filteredRoomReserve.updateReservationDateEnd(roomReserveUpdateRequestDto.getReservationDateEnd());
         }
 
+        LocalDateTime reservationDate = filteredRoomReserve.getReservationDate();
+        LocalDateTime reservationDateEnd = filteredRoomReserve.getReservationDateEnd();
+
+        for(RoomReserve existingReserve: roomReserveList){
+            // 기존의 자신의 예약과의 비교는 제외
+            if(!existingReserve.getId().equals(filteredRoomReserve.getId())){
+                // 기존 예약 시간
+                LocalDateTime existingStartTime = existingReserve.getReservationDate();
+                LocalDateTime existingEndTime = existingReserve.getReservationDateEnd();
+
+                // 예약이 겹치는 Case 3가지를 판별하는 로직.
+                boolean isOverlap = reservationDate.isBefore(existingEndTime) && reservationDateEnd.isAfter(existingStartTime);
+
+                // 겹치는 예약? -> Exception
+                if(isOverlap){
+                    throw new RoomReserveOverlapException();
+                }
+            }
+        }
+
         return new RoomReserveUpdateResponseDto(filteredRoomReserve);
+    }
+
+    @Transactional
+    public RoomReserveDeleteResponseDto deleteRoomReserve(UserDetailsImpl userDetails, Long roomId, Long reserveId) {
+        // 요청자 권한 확인 - 멤버쉽 권한이 아니면 예외처리.
+        User user = userDetails.getUser();
+
+        // 예약 정보 확인.
+        Room room = roomService.findRoomById(roomId);
+
+        RoomReserve filteredRoomReserve = room.getRoomReservations().stream()
+                .filter(reserve -> reserve.getId().equals(reserveId))
+                .findFirst().orElseThrow(NotFoundRoomReserveException::new);
+
+        // 스터디룸 예약을 했던 유저만이 스터디룸 예약을 삭제 할 수 있다.
+        if(!filteredRoomReserve.getUser().getId().equals(userDetails.getUser().getId())){
+            throw new ReservationDeleteNotAllowedException();
+        }
+
+        roomReserveRepository.delete(filteredRoomReserve);
+
+        return new RoomReserveDeleteResponseDto(filteredRoomReserve);
     }
 }


### PR DESCRIPTION
스터디룸 예약에 대한 수정/삭제/조회 기능을 추가했습니다.

스터디룸 수정 시에는 수정되는 시간과 기존의 예약 정보들 간의 겹침 유무에 집중하여 작성했습니다.

스터디룸 조회 에는 조회할 스터디룸Id 에 대한 모든 예약 정보를 조회하는 기능과, 요청자의 예약 정보를 조회하는 기능을 
페이지네이션을 적용하여 작성했습니다.

스터디룸과 스터디룸 예약에 관한 기본적인 CRUD 기능들은 완료되었고

튜터님께서 S.A에 남겨주신 동시성 이슈에 대한 처리 요소를 고민하였고, 여러 트랜잭션에서의 같은 시간예약 생성과
새로운 예약과 기존예약의 변경이 같은 시간에 처리될 경우에 동시성 이슈에 대한 처리가 필요할 수 있을거라 생각되어
그 부분에 조사와 적용을 시도하고있습니다.

이 부분은 주말간 테스트코드 작성과 함께 따로 PR 올리겠습니다.

.

