### PR TITLE
Features/book reservation

### DIFF
--- a/src/main/java/com/example/library_management/LibraryManagementApplication.java
+++ b/src/main/java/com/example/library_management/LibraryManagementApplication.java
@@ -4,9 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 @Slf4j
 public class LibraryManagementApplication {
 

--- a/src/main/java/com/example/library_management/domain/bookCopy/dto/BookCopyRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/bookCopy/dto/BookCopyRequestDto.java
@@ -1,10 +1,12 @@
 package com.example.library_management.domain.bookCopy.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 public class BookCopyRequestDto {
     private Long bookId;
     private LocalDate registeredAt;

--- a/src/main/java/com/example/library_management/domain/bookCopy/entity/BookCopy.java
+++ b/src/main/java/com/example/library_management/domain/bookCopy/entity/BookCopy.java
@@ -6,6 +6,7 @@ import com.example.library_management.domain.bookReservation.entity.BookReservat
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "book_copy")
 @NoArgsConstructor
 public class BookCopy {

--- a/src/main/java/com/example/library_management/domain/bookCopy/entity/BookCopy.java
+++ b/src/main/java/com/example/library_management/domain/bookCopy/entity/BookCopy.java
@@ -23,6 +23,9 @@ public class BookCopy {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @Column(nullable = false)
     private LocalDate registeredAt;
 

--- a/src/main/java/com/example/library_management/domain/bookCopy/repository/BookCopyRepository.java
+++ b/src/main/java/com/example/library_management/domain/bookCopy/repository/BookCopyRepository.java
@@ -1,7 +1,11 @@
 package com.example.library_management.domain.bookCopy.repository;
 
+import com.example.library_management.domain.book.entity.Book;
 import com.example.library_management.domain.bookCopy.entity.BookCopy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BookCopyRepository extends JpaRepository<BookCopy, Long> {
+    List<BookCopy> findAllByBookAndRentableTrue(Book book);
 }

--- a/src/main/java/com/example/library_management/domain/bookRental/controller/bookRentalController.java
+++ b/src/main/java/com/example/library_management/domain/bookRental/controller/bookRentalController.java
@@ -3,6 +3,7 @@ package com.example.library_management.domain.bookRental.controller;
 import com.example.library_management.domain.bookRental.dto.BookRentalRequestDto;
 import com.example.library_management.domain.bookRental.dto.BookRentalResponseDto;
 import com.example.library_management.domain.bookRental.entity.BookRental;
+import com.example.library_management.domain.bookRental.exception.DiffrentBookCopyReservationException;
 import com.example.library_management.domain.bookRental.service.BookRentalService;
 import com.example.library_management.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ public class bookRentalController {
     private final BookRentalService bookRentalService;
 
     @PostMapping
-    public ResponseEntity<BookRentalResponseDto> submitBookRental(@RequestBody BookRentalRequestDto bookRentalRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<BookRentalResponseDto> submitBookRental(@RequestBody BookRentalRequestDto bookRentalRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) throws DiffrentBookCopyReservationException {
         BookRentalResponseDto bookRentalResponseDto = bookRentalService.submitBookRental(bookRentalRequestDto, userDetails);
         return ResponseEntity.ok(bookRentalResponseDto);
     }

--- a/src/main/java/com/example/library_management/domain/bookRental/exception/DiffrentBookCopyReservationException.java
+++ b/src/main/java/com/example/library_management/domain/bookRental/exception/DiffrentBookCopyReservationException.java
@@ -1,0 +1,9 @@
+package com.example.library_management.domain.bookRental.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DiffrentBookCopyReservationException extends RuntimeException {
+    public DiffrentBookCopyReservationException(Long id) {
+        super(HttpStatus.BAD_REQUEST+ " 대여 예약된 서적은 ID : " + id + " 서적입니다.");
+    }
+}

--- a/src/main/java/com/example/library_management/domain/bookRental/service/BookRentalService.java
+++ b/src/main/java/com/example/library_management/domain/bookRental/service/BookRentalService.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class BookRentalService {
     private final BookRentalRepository bookRentalRepository;
     private final BookCopyRepository bookCopyRepository;
@@ -36,6 +35,7 @@ public class BookRentalService {
         return userDetails.getUser().getRole().equals(UserRole.ROLE_ADMIN);
     }
 
+    @Transactional
     public BookRentalResponseDto submitBookRental(BookRentalRequestDto bookRentalRequestDto, UserDetailsImpl userDetails) {
         if(!validateUser(userDetails)) {
             throw new AuthorizedAdminException();
@@ -64,6 +64,7 @@ public class BookRentalService {
         return new BookRentalResponseDto(savedBookRental);
     }
 
+    @Transactional
     public BookRentalResponseDto returnBookRental(BookRentalRequestDto bookRentalRequestDto, UserDetailsImpl userDetails) {
         if(!validateUser(userDetails)) {
             throw new AuthorizedAdminException();
@@ -87,6 +88,7 @@ public class BookRentalService {
         return new BookRentalResponseDto(returnedBookRental);
     }
 
+    @Transactional
     public Long deleteBookRental(Long bookRentalId, UserDetailsImpl userDetails) {
         if(!validateUser(userDetails)) {
             throw new AuthorizedAdminException();

--- a/src/main/java/com/example/library_management/domain/bookReservation/controller/BookReservationController.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/controller/BookReservationController.java
@@ -1,15 +1,18 @@
 package com.example.library_management.domain.bookReservation.controller;
 
+import com.example.library_management.domain.bookReservation.dto.BookReservationRequestDto;
+import com.example.library_management.domain.bookReservation.dto.BookReservationResponseDto;
 import com.example.library_management.domain.bookReservation.entity.BookReservation;
 import com.example.library_management.domain.bookReservation.repository.BookReservationRepository;
 import com.example.library_management.domain.bookReservation.service.BookReservationService;
 import com.example.library_management.global.security.UserDetailsImpl;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,9 +20,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookReservationController {
     private final BookReservationService bookReservationService;
 
+    // 책 대여 예약은 예약일자로부터 3일 이내에 대여해야 함.
     @PostMapping
-    public BookReservation submitBookReservation(@RequestBody BookReservation bookReservation, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<BookReservationResponseDto> submitBookReservation(@RequestBody BookReservationRequestDto bookReservationRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        BookReservationResponseDto bookReservationResponseDto = bookReservationService.submitBookReservation(bookReservationRequestDto, userDetails);
 
-        return null;
+        return ResponseEntity.ok(bookReservationResponseDto);
+    }
+
+    @DeleteMapping("/{bookReservationId}")
+    public ResponseEntity<Long> deleteBookReservation(@PathVariable("bookReservationId") Long bookReservationId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long deletedBookReservationId =  bookReservationService.deleteBookReservation(bookReservationId, userDetails);
+        return ResponseEntity.ok(deletedBookReservationId);
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<BookReservationResponseDto>> getBookReservations(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<BookReservationResponseDto> bookReservationResponseDtoList = bookReservationService.getBookReservations(userDetails);
+
+        return ResponseEntity.ok(bookReservationResponseDtoList);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<BookReservationResponseDto>> getBookReservationsByUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<BookReservationResponseDto> bookReservationResponseDtoList = bookReservationService.getBookReservationsByUser(userDetails);
+        return ResponseEntity.ok(bookReservationResponseDtoList);
     }
 }

--- a/src/main/java/com/example/library_management/domain/bookReservation/dto/BookReservationRequestDto.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/dto/BookReservationRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.bookReservation.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class BookReservationRequestDto {
+    private Long bookId;
+    private LocalDate reservationDate;
+}

--- a/src/main/java/com/example/library_management/domain/bookReservation/dto/BookReservationResponseDto.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/dto/BookReservationResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.library_management.domain.bookReservation.dto;
+
+import com.example.library_management.domain.bookReservation.entity.BookReservation;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class BookReservationResponseDto {
+    private Long bookCopyId;
+    private LocalDate reservationDate;
+
+    public BookReservationResponseDto(BookReservation bookReservation) {
+        this.bookCopyId = bookReservation.getBookCopy().getId();
+        this.reservationDate = bookReservation.getReservationDate();
+    }
+}

--- a/src/main/java/com/example/library_management/domain/bookReservation/entity/BookReservation.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/entity/BookReservation.java
@@ -4,19 +4,23 @@ import com.example.library_management.domain.bookCopy.entity.BookCopy;
 import com.example.library_management.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Entity
 @Getter
 @Table(name = "book_reservation")
+@NoArgsConstructor
 public class BookReservation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime reservationDate;
+    private LocalDate reservationDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_copy_id")
@@ -25,4 +29,10 @@ public class BookReservation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public BookReservation(LocalDate now, BookCopy bookCopy, User user) {
+        this.reservationDate = now;
+        this.bookCopy = bookCopy;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/example/library_management/domain/bookReservation/entity/BookReservation.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/entity/BookReservation.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Optional;
 
 @Entity
@@ -22,6 +23,10 @@ public class BookReservation {
     @Column(nullable = false)
     private LocalDate reservationDate;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReservatationState state;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_copy_id")
     private BookCopy bookCopy;
@@ -34,5 +39,21 @@ public class BookReservation {
         this.reservationDate = now;
         this.bookCopy = bookCopy;
         this.user = user;
+        this.state = ReservatationState.ACTIVE;
+    }
+
+    public void expireReservation() {
+        this.state = ReservatationState.EXPIRED;
+    }
+
+    public void finishReservation() {
+        this.state = ReservatationState.FINISHED;
+        LocalTime now = LocalTime.now();
+        LocalTime start = LocalTime.of(23, 50, 0); // 12시 직전
+        LocalTime end = LocalTime.of(0, 9, 59); // 12시 직후
+
+        if (now.isAfter(start) && now.isBefore(end)) {
+            throw new IllegalStateException("23:50 ~ 00:10 동안에는 예약 상태를 변경할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/example/library_management/domain/bookReservation/entity/ReservatationState.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/entity/ReservatationState.java
@@ -1,0 +1,7 @@
+package com.example.library_management.domain.bookReservation.entity;
+
+public enum ReservatationState {
+    ACTIVE,
+    EXPIRED,
+    FINISHED
+}

--- a/src/main/java/com/example/library_management/domain/bookReservation/exception/FindBookReservationException.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/exception/FindBookReservationException.java
@@ -1,0 +1,10 @@
+package com.example.library_management.domain.bookReservation.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+import com.example.library_management.domain.common.exception.GlobalExceptionConst;
+
+public class FindBookReservationException extends GlobalException {
+    public FindBookReservationException() {
+        super(GlobalExceptionConst.NOT_FOUND_BOOK_RESERVATION);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/bookReservation/exception/NotRentableBookException.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/exception/NotRentableBookException.java
@@ -1,0 +1,10 @@
+package com.example.library_management.domain.bookReservation.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+import com.example.library_management.domain.common.exception.GlobalExceptionConst;
+
+public class NotRentableBookException extends GlobalException {
+    public NotRentableBookException() {
+        super(GlobalExceptionConst.NOT_FOUND_RENTABLE_BOOKCOPY);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/bookReservation/repository/BookReservationRepository.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/repository/BookReservationRepository.java
@@ -1,8 +1,12 @@
 package com.example.library_management.domain.bookReservation.repository;
 
 import com.example.library_management.domain.bookReservation.entity.BookReservation;
+import com.example.library_management.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 public interface BookReservationRepository extends JpaRepository<BookReservation, Long> {
+    List<BookReservation> findAllByUser(User user);
 }

--- a/src/main/java/com/example/library_management/domain/bookReservation/repository/BookReservationRepository.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/repository/BookReservationRepository.java
@@ -1,12 +1,16 @@
 package com.example.library_management.domain.bookReservation.repository;
 
 import com.example.library_management.domain.bookReservation.entity.BookReservation;
+import com.example.library_management.domain.bookReservation.entity.ReservatationState;
 import com.example.library_management.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface BookReservationRepository extends JpaRepository<BookReservation, Long> {
     List<BookReservation> findAllByUser(User user);
+
+    List<BookReservation> findByReservationDateBeforeAndState(LocalDate threeDaysAgo, ReservatationState reservatationState);
 }

--- a/src/main/java/com/example/library_management/domain/bookReservation/scheduler/BookReservationScheduler.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/scheduler/BookReservationScheduler.java
@@ -1,0 +1,19 @@
+package com.example.library_management.domain.bookReservation.scheduler;
+
+import com.example.library_management.domain.bookReservation.service.BookReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookReservationScheduler {
+    private final BookReservationService bookReservationService;
+
+    // 매일 0시에 실행 (크론 표현식 사용)
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateReservationStates() {
+        bookReservationService.expireOverdueReservations();
+    }
+}
+

--- a/src/main/java/com/example/library_management/domain/bookReservation/service/BookReservationService.java
+++ b/src/main/java/com/example/library_management/domain/bookReservation/service/BookReservationService.java
@@ -1,14 +1,104 @@
 package com.example.library_management.domain.bookReservation.service;
 
+import com.example.library_management.domain.book.entity.Book;
+import com.example.library_management.domain.book.exception.AuthorizedAdminException;
+import com.example.library_management.domain.book.exception.FindBookException;
+import com.example.library_management.domain.book.repository.BookRepository;
+import com.example.library_management.domain.bookCopy.entity.BookCopy;
+import com.example.library_management.domain.bookCopy.exception.FindBookCopyException;
+import com.example.library_management.domain.bookCopy.repository.BookCopyRepository;
+import com.example.library_management.domain.bookReservation.dto.BookReservationRequestDto;
+import com.example.library_management.domain.bookReservation.dto.BookReservationResponseDto;
+import com.example.library_management.domain.bookReservation.entity.BookReservation;
+import com.example.library_management.domain.bookReservation.exception.FindBookReservationException;
+import com.example.library_management.domain.bookReservation.exception.NotRentableBookException;
 import com.example.library_management.domain.bookReservation.repository.BookReservationRepository;
+import com.example.library_management.domain.user.entity.User;
+import com.example.library_management.domain.user.enums.UserRole;
+import com.example.library_management.domain.user.exception.NotFoundUserException;
+import com.example.library_management.global.security.UserDetailsImpl;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class BookReservationService {
     private final BookReservationRepository bookReservationRepository;
+    private final BookRepository bookRepository;
+    private final BookCopyRepository bookCopyRepository;
 
+
+    public BookReservationResponseDto submitBookReservation(BookReservationRequestDto bookReservationRequestDto, UserDetailsImpl userDetails) {
+        // + 유저 멤버쉽 확인
+        // + 유저 검증 -> 대여 가능한 상태인지? 아래 유저 검증이랑 합치기
+        User user = userDetails.getUser();
+        if(user == null) {
+            throw new NotFoundUserException();
+        }
+
+        Book book = bookRepository.findById(bookReservationRequestDto.getBookId()).orElseThrow(FindBookException::new);
+        Optional<BookCopy> bookCopyOpt = bookCopyRepository.findAllByBookAndRentableTrue(book).stream().findFirst();
+
+        if(!bookCopyOpt.isPresent()) {
+            throw new NotRentableBookException();
+        }
+
+        BookCopy bookCopy = bookCopyOpt.get();
+        bookCopy.setRentable(false);
+
+        BookReservation bookReservation = new BookReservation(LocalDate.now(), bookCopy, user);
+
+        bookCopyRepository.save(bookCopy);
+
+        BookReservation savedBookReservation = bookReservationRepository.save(bookReservation);
+
+        return new BookReservationResponseDto(savedBookReservation);
+    }
+
+    // 기한 만료시 자동으로 호출될 로직
+    public Long deleteBookReservation(Long bookReservationId, UserDetailsImpl userDetails) {
+        if(!validateUserAdmin(userDetails)){
+            throw new AuthorizedAdminException();
+        }
+
+        BookReservation bookReservation = bookReservationRepository.findById(bookReservationId).orElseThrow(FindBookReservationException::new);
+
+        BookCopy bookCopy = bookCopyRepository.findById(bookReservation.getBookCopy().getId()).orElseThrow(FindBookCopyException::new);
+
+        bookCopy.setRentable(true);
+
+        bookCopyRepository.save(bookCopy);
+        bookReservationRepository.delete(bookReservation);
+
+        return bookReservationId;
+    }
+
+    public Boolean validateUserAdmin(UserDetailsImpl userDetails) {
+        return userDetails.getUser().getRole().equals(UserRole.ROLE_ADMIN);
+    }
+
+    public List<BookReservationResponseDto> getBookReservations(UserDetailsImpl userDetails) {
+        if(!validateUserAdmin(userDetails)){
+            throw new AuthorizedAdminException();
+        }
+
+        List<BookReservation> bookReservationList = bookReservationRepository.findAll();
+
+        return bookReservationList.stream().map(BookReservationResponseDto::new).toList();
+    }
+
+    public List<BookReservationResponseDto> getBookReservationsByUser(UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+
+        List<BookReservation> bookReservationList = bookReservationRepository.findAllByUser(user);
+        return bookReservationList.stream().map(BookReservationResponseDto::new).toList();
+    }
+
+    // 예약일 + 3일째에 대여 안하면 예약 취소
 }

--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -39,6 +39,8 @@ public enum GlobalExceptionConst {
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, " 댓글을 찾을 수 없습니다."),
     NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, " 스터디룸이 존재하지 않습니다."),
     NOT_FOUND_ROOM_RESERVE(HttpStatus.NOT_FOUND, " 스터디룸 예약이 존재하지 않습니다."),
+    NOT_FOUND_RENTABLE_BOOKCOPY(HttpStatus.NOT_FOUND, "대여 가능한 서적이 존재하지 않습니다."),
+    NOT_FOUND_BOOK_RESERVATION(HttpStatus.NOT_FOUND, "존재하지 않는 책 대여 예약 정보입니다."),
 
     // 상태코드 409
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다."),

--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.library_management.domain.common.exception;
 
+import com.example.library_management.domain.bookRental.exception.DiffrentBookCopyReservationException;
 import com.example.library_management.domain.common.dto.ErrorResponse;
 import com.example.library_management.global.config.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,14 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(500, e.getMessage());
         return ResponseEntity
                 .status(500)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    @ExceptionHandler(DiffrentBookCopyReservationException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleDiffrentBookCopyReservationException(DiffrentBookCopyReservationException e) {
+        ErrorResponse errorResponse = new ErrorResponse(400, e.getMessage());
+        return ResponseEntity
+                .status(400)
                 .body(ApiResponse.error(errorResponse));
     }
 }

--- a/src/test/java/com/example/library_management/domain/bookCopy/bookCopyService/BookCopyServiceTest.java
+++ b/src/test/java/com/example/library_management/domain/bookCopy/bookCopyService/BookCopyServiceTest.java
@@ -1,0 +1,113 @@
+package com.example.library_management.domain.bookCopy.bookCopyService;
+
+import com.example.library_management.domain.book.entity.Book;
+import com.example.library_management.domain.book.repository.BookRepository;
+import com.example.library_management.domain.bookCategory.entity.BookCategory;
+import com.example.library_management.domain.bookCopy.dto.BookCopyRequestDto;
+import com.example.library_management.domain.bookCopy.dto.BookCopyResponseDto;
+import com.example.library_management.domain.bookCopy.entity.BookCopy;
+import com.example.library_management.domain.bookCopy.repository.BookCopyRepository;
+import com.example.library_management.domain.bookCopy.service.BookCopyService;
+import com.example.library_management.domain.user.entity.User;
+import com.example.library_management.domain.user.enums.UserRole;
+import com.example.library_management.global.security.UserDetailsImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public class BookCopyServiceTest {
+
+    @InjectMocks
+    private BookCopyService bookCopyService;
+
+    @Mock
+    private BookCopyRepository bookCopyRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    private User user;
+    private UserDetailsImpl userDetails;
+
+    private Book book;
+    private BookCategory bookCategory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.
+                initMocks(this);
+
+        user = new User();
+        user.setRole(UserRole.ROLE_ADMIN);
+        userDetails = new UserDetailsImpl(user);
+
+        bookCategory = new BookCategory();
+        bookCategory.setId(1L);
+        bookCategory.setCategoryName("문학");
+
+        book = new Book();
+        book.setId(1L);
+        book.setBookTitle("아프리카 청춘");
+        book.setCategory(bookCategory);
+    }
+
+    @Test
+    void testAddBookCopy() {
+        // Arrange
+        BookCopy bookCopy = new BookCopy(book, LocalDate.now());
+        bookCopy.setId(1L);
+
+        BookCopyRequestDto bookCopyRequestDto = new BookCopyRequestDto();
+        bookCopyRequestDto.setBookId(bookCopy.getBook().getId());
+        bookCopyRequestDto.setRegisteredAt(bookCopy.getRegisteredAt());
+
+        when(bookRepository.findById(bookCopyRequestDto.getBookId())).thenReturn(Optional.of(book));
+        when(bookCopyRepository.save(any(BookCopy.class))).thenReturn(bookCopy);
+
+        // Act
+        BookCopyResponseDto bookCopyResponseDto = bookCopyService.addBookCopy(bookCopyRequestDto, userDetails);
+
+        // Assert
+        assertNotNull(bookCopyResponseDto);
+        verify(bookCopyRepository).save(any(BookCopy.class));
+        assertEquals("아프리카 청춘", bookCopyResponseDto.getBookTitle());
+    }
+
+    @Test
+    void testUpdateBookCopy() {
+        BookCopy bookCopy = new BookCopy(book, LocalDate.now());
+        bookCopy.setId(1L);
+
+        Book book2 = new Book();
+        book2.setId(2L);
+        book2.setBookTitle("신");
+        book2.setCategory(bookCategory);
+
+        BookCopyRequestDto bookCopyRequestDto = new BookCopyRequestDto();
+        bookCopyRequestDto.setBookId(book2.getId());
+
+        when(bookRepository.findById(2L)).thenReturn(Optional.of(book2));
+        when(bookCopyRepository.findById(1L)).thenReturn(Optional.of(bookCopy));
+        when(bookCopyRepository.save(any(BookCopy.class))).thenReturn(bookCopy);
+
+        BookCopyResponseDto bookCopyResponseDto = bookCopyService.updateBookCopy(bookCopyRequestDto, userDetails, 1L);
+
+        assertNotNull(bookCopyResponseDto);
+        verify(bookCopyRepository).save(any(BookCopy.class));
+        assertEquals("신", bookCopyResponseDto.getBookTitle());
+    }
+
+
+}

--- a/src/test/java/com/example/library_management/domain/bookRental/service/BookRentalServiceTest.java
+++ b/src/test/java/com/example/library_management/domain/bookRental/service/BookRentalServiceTest.java
@@ -1,0 +1,33 @@
+package com.example.library_management.domain.bookRental.service;
+
+import com.example.library_management.domain.bookCopy.repository.BookCopyRepository;
+import com.example.library_management.domain.bookRental.entity.BookRental;
+import com.example.library_management.domain.bookRental.repository.BookRentalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class BookRentalServiceTest {
+    @InjectMocks
+    private BookRentalService bookRentalService;
+
+    @Mock
+    private BookRentalRepository bookRentalRepository;
+
+    @Mock
+    private BookCopyRepository bookCopyRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void submitBookRental() {
+        BookRental bookRental = new BookRental();
+    }
+
+
+}


### PR DESCRIPTION
책 대여 예약 로직 구현

1. 대여 예약 신청 시 Book ID를 입력받으며, 해당 Book ID로 등록된 복본(BookCopy) 중, 현재 대여 가능한 복본이 존재하는지 확인하고 대여 가능한 복본을 통해 대여 예약 신청
 - 대여 예약 신청 시 해당 복본은 대여 불가 상태로 변경함.
 - 대여 예약 신청 시, 낙관적 락을 사용하여 복본 상태변화의 충돌을 감지하여 동시성 제어

2. 대여 예약 신청 후 3일이 경과한 날 자정에, 대여 예약 진행상황이 여전히 'ACTIVE'인 대여 예약을 조회하여, 해당 대여 예약을 'EXPIRE"로 업데이트하여 만료처리.
 - 스케줄러를 통하여 해당 이벤트 처리
 - 스케줄러를 00시 00분으로 설정하고, 전후 10분 동안은 복본에 대한 상태 업데이트를 거부하는 로직을 추가하여, 해당 이벤트 처리 중 동시성 이슈가 발생하는 경우를 미연에 차단함.

3. 유저가 대여하려는 복본과 동일한 Book ID를 가진 복본의 대여 예약 내역이 '진행중'일 경우, 해당 대여 신청을 거부하고 예외처리
 - 예외처리 시, 예약된 복본의 ID를 전달하는 예외 메시지 전송
