### PR TITLE
[update] RoomReserve 동시성 처리 추가 완료

### DIFF
--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -48,6 +48,7 @@ public enum GlobalExceptionConst {
     RENTAL_NOT_POSSIBLE(HttpStatus.CONFLICT, " 현재 대여 불가능한 서적입니다."),
     ALREADY_RETURN(HttpStatus.CONFLICT, " 이미 반납된 서적입니다."),
     ROOM_RESERVE_OVERLAP(HttpStatus.CONFLICT, "예약 시간이 겹쳐 예약이 불가능합니다."),
+    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, "다른 사용자에 의해 예약 충돌이 발생하였습니다, 새로고침 후 재시도해주세요."),
 
     // 상태코드 422
     ROOM_RESERVE_UNPROCESSABLE(HttpStatus.UNPROCESSABLE_ENTITY, "해당 스터디룸 에약이 불가능합니다.");

--- a/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
+++ b/src/main/java/com/example/library_management/domain/common/exception/GlobalExceptionConst.java
@@ -43,11 +43,15 @@ public enum GlobalExceptionConst {
     NOT_FOUND_RENTABLE_BOOKCOPY(HttpStatus.NOT_FOUND, "대여 가능한 서적이 존재하지 않습니다."),
     NOT_FOUND_BOOK_RESERVATION(HttpStatus.NOT_FOUND, "존재하지 않는 책 대여 예약 정보입니다."),
 
+    // 상태코드 408
+    REQUEST_LOCK_TIME_OUT(HttpStatus.REQUEST_TIMEOUT, "예약 처리중 잠금 대기 시간이 초과되었습니다."),
+
     // 상태코드 409
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, " 중복된 이메일입니다."),
     RENTAL_NOT_POSSIBLE(HttpStatus.CONFLICT, " 현재 대여 불가능한 서적입니다."),
     ALREADY_RETURN(HttpStatus.CONFLICT, " 이미 반납된 서적입니다."),
     ROOM_RESERVE_OVERLAP(HttpStatus.CONFLICT, "예약 시간이 겹쳐 예약이 불가능합니다."),
+    ROOM_RESERVE_EXCEPTION(HttpStatus.CONFLICT, "예약 시도 중 오류가 발생했습니다."),
     OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, "다른 사용자에 의해 예약 충돌이 발생하였습니다, 새로고침 후 재시도해주세요."),
 
     // 상태코드 422

--- a/src/main/java/com/example/library_management/domain/membership/repository/MembershipPaymentRepository.java
+++ b/src/main/java/com/example/library_management/domain/membership/repository/MembershipPaymentRepository.java
@@ -32,5 +32,5 @@ public interface MembershipPaymentRepository extends JpaRepository<MembershipPay
 
     // 특정 멤버십의 가장 최근 결제 정보를 조회
     @Query("SELECT mp FROM MembershipPayment mp WHERE mp.membership = :membership ORDER BY mp.createdAt DESC")
-    Optional<MembershipPayment> findTopByMembershipOrderByCreatedAtDesc(@Param("membership") Membership activeMembership);
+    Optional<MembershipPayment> findTopByMembershipOrderByCreatedAtDesc(@Param("membership") Membership membership);
 }

--- a/src/main/java/com/example/library_management/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/library_management/domain/room/service/RoomService.java
@@ -12,12 +12,10 @@ import com.example.library_management.domain.room.exception.UnauthorizedRoomAcce
 import com.example.library_management.domain.room.repository.RoomRepository;
 import com.example.library_management.domain.user.entity.User;
 import com.example.library_management.domain.user.enums.UserRole;
-import com.example.library_management.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -85,7 +83,6 @@ public class RoomService {
     public void validateRoomAccess(User user){
         // 사용자가 ADMIN 권한을 가지고 있는지 확인
         boolean isAdmin = user.getRole().equals(UserRole.ROLE_ADMIN);
-        System.out.println("권한 :"+user.getRole());
 
         if (!isAdmin) {
             throw new UnauthorizedRoomAccessException();

--- a/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/entity/RoomReserve.java
@@ -32,6 +32,10 @@ public class RoomReserve extends Timestamped {
     @JoinColumn(name = "room_id")
     private Room room;
 
+    // 낙관적 락 적용, RoomReserve 엔티티의 변경을 감지하여 버전충돌을 확인. -> 충돌시 OptimisticLockException 발생 테스트코드에서 활용.
+    @Version
+    private Integer version;
+
     public static RoomReserve createReservation(Room room, User user, RoomReserveCreateRequestDto roomReserveCreateRequestDto) {
         RoomReserve roomReserve = new RoomReserve();
         roomReserve.room = room;

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/OptimisticLockConflictException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/OptimisticLockConflictException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.OPTIMISTIC_LOCK_CONFLICT;
+
+public class OptimisticLockConflictException extends GlobalException {
+    public OptimisticLockConflictException() {
+        super(OPTIMISTIC_LOCK_CONFLICT);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationLockTimeOutException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/ReservationLockTimeOutException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.REQUEST_LOCK_TIME_OUT;
+
+public class ReservationLockTimeOutException extends GlobalException {
+    public ReservationLockTimeOutException() {
+        super(REQUEST_LOCK_TIME_OUT);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveException.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/exception/RoomReserveException.java
@@ -1,0 +1,11 @@
+package com.example.library_management.domain.roomReserve.exception;
+
+import com.example.library_management.domain.common.exception.GlobalException;
+
+import static com.example.library_management.domain.common.exception.GlobalExceptionConst.ROOM_RESERVE_EXCEPTION;
+
+public class RoomReserveException extends GlobalException {
+    public RoomReserveException() {
+        super(ROOM_RESERVE_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
+++ b/src/main/java/com/example/library_management/domain/roomReserve/repository/RoomReserveRepository.java
@@ -13,10 +13,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RoomReserveRepository extends JpaRepository<RoomReserve, Long> {
-    // 스터디룸 예약 - 동시성 제어 로직 (Pessimistic Lock)
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+
     @Query("SELECT r FROM RoomReserve r WHERE r.room.id = :roomId")
-    List<RoomReserve> findAllByRoomIdWithLock(@Param("roomId") Long roomId);
+    List<RoomReserve> findAllByRoomId(@Param("roomId") Long roomId);
 
     @Query("SELECT r FROM RoomReserve r WHERE r.user.id = :userId AND r.room.id = :roomId")
     Page<RoomReserve> findAllByUserIdAndRoomId(@Param("userId") Long userId, @Param("roomId") Long roomId, Pageable pageable);


### PR DESCRIPTION
RoomReserve 생성 및 수정 요청에 대해서 동시성 처리를 추가했습니다.

해당 프로그램이 적용될 시스템의 환경을 고려하여 특정 기간 (4,5,6,7월을 기준으로, 해당 기준은 해당 프로그램이 도입될 시스템에 따라 달라질 수 있습니다.)을 트래픽이 상승하는 기간임을 고려하여

LocalDateTime의 getMonthValue()를 사용하여 요청이 들어온 시간에 따라 

트래픽이 높은 시기에는 낙관적 락과 Redis의 분산락을 혼용한 방식의 로직을.
트래픽이 낮은 시기에는 낙관적 락만을 사용한 로직을 동적으로 전환하며 수행할 수 있도록 작성했습니다.

해당 기능에 대해서는 Postman을 사용한 테스트는 완료한 상태이며, 현재 로직이 변경되었기 때문에 
RoomReserve에 대한 테스트코드가 동작하지 않고있습니다, 이 부분 참고부탁드리고 

주말간 스케쥴러를 도입하여 지나간 예약 요청에 대한 삭제 처리 기능 추가 후 로직이 확정되면 다시 테스트코드를 맞게 작성 
하도록 하겠습니다, 테스트코드 작성간에는 튜터님께서 조언해주신 Jmeter도 한번 찾아보고 동시성 이슈가 잘 처리되는지 확인해보겠습니다.